### PR TITLE
fix: sanitize logo preview URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.tokensave

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -99,20 +99,38 @@ function prefillDimensionsFromLoadedImage() {
     }
 }
 
+function normalizeLogoPreviewUrl(value) {
+    const url = value.trim();
+    if (!url) {
+        return '';
+    }
+
+    try {
+        const parsedUrl = new URL(url, window.location.href);
+        if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+            return '';
+        }
+
+        return parsedUrl.href;
+    } catch (error) {
+        return '';
+    }
+}
+
 function updateLogoPreview() {
     const { input, preview, error } = getPreviewElements();
     if (!input || !preview || !error) {
         return;
     }
 
-    const url = input.value.trim();
+    const url = normalizeLogoPreviewUrl(input.value);
     error.classList.add('logo-preview-hidden');
 
     if (url) {
         preview.src = url;
         preview.classList.remove('logo-preview-hidden');
     } else {
-        preview.src = '';
+        preview.removeAttribute('src');
         preview.classList.add('logo-preview-hidden');
         error.classList.add('logo-preview-hidden');
     }
@@ -173,7 +191,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     input.addEventListener('blur', function () {
-        const url = input.value.trim();
+        const url = normalizeLogoPreviewUrl(input.value);
         const hasLocalUpload = fileInput && fileInput.files && fileInput.files.length > 0;
         if (hasLocalUpload) {
             return;
@@ -190,7 +208,7 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
-        const url = input.value.trim();
+        const url = normalizeLogoPreviewUrl(input.value);
         const hasLocalUpload = fileInput && fileInput.files && fileInput.files.length > 0;
         if (hasLocalUpload) {
             return;


### PR DESCRIPTION
## Summary

- Normalize the admin preview URL before assigning it to the image `src`
- Strip invalid or non-`http(s)` values from the live preview flow
- Keep the admin preview and insecure-URL checks aligned

## Notes

- No co-author added
- Includes the current `.gitignore` update for `.tokensave`
